### PR TITLE
Feature/single val for const inputs

### DIFF
--- a/include/context-helib.hpp
+++ b/include/context-helib.hpp
@@ -504,7 +504,6 @@ public:
     if (pt_len > this->m_nslots) {
 			throw std::runtime_error("The number of slots is greater than the number of SIMD operations that can be done at a time");
     }
-    std::cout<<"pt_len, nslots are "<<pt_len<<" "<<this->m_nslots<<std::endl;
     // convert plaintext input into a vector of longs
     for (int i = 0; i < pt_len; i++) {
       ptvec.push_back(pt[i]);
@@ -513,7 +512,6 @@ public:
     for (int i = pt_len; i < this-> m_nslots; i++) {
       ptvec.push_back(0);
     }
-    std::cout<<" size of ptvec "<<ptvec.size()<<std::endl;
     // fill up nslots with zeros////
     for (int i = ptvec.size(); i < this->m_nslots; i++) ptvec.push_back(0);
 

--- a/include/context.hpp
+++ b/include/context.hpp
@@ -60,7 +60,7 @@ public:
 	// overload taking both durations and const_plaintext_inputs
 	virtual std::vector<std::vector<PlaintextT>>
 	eval_with_plaintexts(const Circuit& C, std::vector<std::vector<PlaintextT>> plaintext_inputs,
-	                     std::vector<std::vector<PlaintextT>> const_plaintext_inputs,
+	                     std::vector<PlaintextT> const_plaintext_inputs,
 	                     std::vector<std::chrono::duration<double, std::micro> >& durations,
 	                     EvaluationStrategy eval_strategy = EvaluationStrategy::serial,
 	                     std::chrono::duration<double, std::micro> timeout = std::chrono::duration<double, std::micro>(0.0)) = 0;
@@ -68,7 +68,7 @@ public:
 	// overload omitting durations only
 	virtual std::vector<std::vector<PlaintextT>>
 	eval_with_plaintexts(const Circuit& C, std::vector<std::vector<PlaintextT>> plaintext_inputs,
-	                     std::vector<std::vector<PlaintextT>> const_plaintext_inputs,
+	                     std::vector<PlaintextT> const_plaintext_inputs,
 	                     EvaluationStrategy eval_strategy = EvaluationStrategy::serial,
 	                     std::chrono::duration<double, std::micro> timeout = std::chrono::duration<double, std::micro>(0.0)) = 0;
 
@@ -78,7 +78,7 @@ public:
 	                     std::vector<std::chrono::duration<double, std::micro> >& durations,
 	                     EvaluationStrategy eval_strategy = EvaluationStrategy::serial,
 	                     std::chrono::duration<double, std::micro> timeout = std::chrono::duration<double, std::micro>(0.0)) = 0;
-	
+
 	// overload omitting both durations and const_plaintext_inputs
 	virtual std::vector<std::vector<PlaintextT>>
 	eval_with_plaintexts(const Circuit& C, std::vector<std::vector<PlaintextT>> plaintext_inputs,
@@ -122,7 +122,7 @@ public:
 
 	virtual Ciphertext dispatch(Gate g,
 				    std::vector<Ciphertext> inputs,
-				    std::vector<std::vector<Plaintext>> const_inputs)
+				    std::vector<Plaintext> const_inputs)
 	{
 		using namespace std::placeholders;
 		switch (g) {
@@ -154,10 +154,10 @@ public:
 			return Select(inputs.at(0), inputs.at(1), inputs.at(2));
 			break;
 		case (Gate::AddConstant):
-			return AddConstant( inputs, (const_inputs.at(0)).at(0));
+			return AddConstant( inputs, const_inputs.at(0));
 			break;
 		case (Gate::MultByConstant):
-			return MultByConstant( inputs, (const_inputs.at(0)).at(0));
+			return MultByConstant( inputs, const_inputs.at(0));
 			break;
 		}
 		throw std::runtime_error("Unknown op");
@@ -169,9 +169,9 @@ public:
 	                 OutputContainer& output_vals,
 	                 const ConstInputContainer& const_input_vals = ConstInputContainer(),
 	                 std::chrono::duration<double, std::micro> timeout = std::chrono::duration<double, std::micro>(0.0)) {
-										 
+
 		std::unordered_map<std::string, Ciphertext> eval_map;
-		std::unordered_map<std::string, std::vector<Plaintext>> const_eval_map;
+		std::unordered_map<std::string, Plaintext> const_eval_map;
 
 		// add Circuit::inputs and inputs into the map
 		auto input_vals_it = input_vals.begin();
@@ -211,7 +211,7 @@ public:
 
 		for (const Assignment assn : circ.get_assignments()) {
 			std::vector<Ciphertext> inputs;
-			std::vector<std::vector<Plaintext>> const_inputs;
+			std::vector<Plaintext> const_inputs;
 			for (Wire w : assn.get_inputs())
 			{
 				typename decltype(eval_map)::iterator it;
@@ -392,11 +392,11 @@ public:
 	// }
 
 	// overload taking both durations and const_plaintext_inputs
-	virtual std::vector<std::vector<PlaintextT>> 
+	virtual std::vector<std::vector<PlaintextT>>
 	eval_with_plaintexts(
 	  const Circuit& C,
 	  std::vector<std::vector<PlaintextT>> plaintext_inputs,
-	  std::vector<std::vector<PlaintextT>> const_plaintext_inputs,
+	  std::vector<PlaintextT> const_plaintext_inputs,
 	  std::vector<std::chrono::duration<double, std::micro> >& durations,
 	  EvaluationStrategy eval_strategy = EvaluationStrategy::serial,
 	  std::chrono::duration<double, std::micro> timeout = std::chrono::duration<double, std::micro>(0.0))
@@ -407,7 +407,7 @@ public:
 
 		/// encrypt the inputs
 		std::vector<Ciphertext> ciphertext_inputs;
-		std::vector<std::vector<Plaintext>> const_inputs;
+		std::vector<Plaintext> const_inputs;
 		for (auto pt : plaintext_inputs) ciphertext_inputs.push_back(encrypt(pt));
 		for (auto cpt : const_plaintext_inputs) const_inputs.push_back(cpt);
 
@@ -451,7 +451,7 @@ public:
 	  EvaluationStrategy eval_strategy = EvaluationStrategy::serial,
 	  std::chrono::duration<double, std::micro> timeout = std::chrono::duration<double, std::micro>(0.0))
 	{
-		std::vector<std::vector<PlaintextT>> cptxts_empty;
+		std::vector<PlaintextT> cptxts_empty;
 		return eval_with_plaintexts(C, plaintext_inputs, cptxts_empty,
 					    durations, eval_strategy, timeout);
 	}
@@ -459,7 +459,7 @@ public:
 	// overload omitting durations only
 	virtual std::vector<std::vector<PlaintextT>>
 	eval_with_plaintexts(const Circuit& c, std::vector<std::vector<PlaintextT>> ptxts,
-	                     std::vector<std::vector<PlaintextT>> cptxts,
+	                     std::vector<PlaintextT> cptxts,
 	                     EvaluationStrategy eval_strategy = EvaluationStrategy::serial,
 	                     std::chrono::duration<double, std::micro> timeout = std::chrono::duration<double, std::micro>(0.0))
 	{
@@ -474,7 +474,7 @@ public:
 	                     std::chrono::duration<double, std::micro> timeout = std::chrono::duration<double, std::micro>(0.0))
 	{
 		std::vector<std::chrono::duration<double, std::micro> > ignored;
-		std::vector<std::vector<Plaintext>> cptxts_empty;
+		std::vector<Plaintext> cptxts_empty;
 		return eval_with_plaintexts(c, ptxts, cptxts_empty, ignored, eval_strategy, timeout);
 	}
 

--- a/include/sheep-server.hpp
+++ b/include/sheep-server.hpp
@@ -38,22 +38,7 @@ using namespace http;
 using namespace utility;
 using namespace http::experimental::listener;
 
-/*
-static std::vector<std::string> available_contexts = {"ClearHElib_Fp",
-						      "HElib_F2",
-						      "TFHE",
-						      "SEAL",
-						      "Clear"};
 
-static std::vector<std::string> available_input_types = {"bool",
-							 "uint8_t",
-							 "uint16_t",
-							 "uint32_t",
-							 "int8_t",
-							 "int16_t",
-							 "int32_t"};
-
-*/
 struct SheepJobConfig {
 	utility::string_t context;
 	utility::string_t input_type;
@@ -63,7 +48,7 @@ struct SheepJobConfig {
 	std::set<std::string> input_names;
 	std::set<std::string> const_input_names;
 	std::vector<std::vector<int>> input_vals;
-	std::vector<std::vector<int>> const_input_vals;
+	std::vector<int> const_input_vals;
 	std::map<std::string, long> parameters;
 
 	void setDefaults() {
@@ -102,13 +87,13 @@ struct SheepJobResult {
 	std::map<std::string, std::vector<std::string>> outputs;  /// store output values as strings so we don't worry about Plaintext type.
 	std::map<std::string, std::string> timings;  /// store time values in microseconds as strings.
 	bool is_correct; /// all outputs compared with clear-context results
-	
+
   json::value as_json() {
 		json::value result = json::value::object();
-		
+
     json::value j_outputs = json::value::object();
 		for ( auto map_iter = outputs.begin(); map_iter != outputs.end(); ++map_iter) {
-			
+
       json::value outputs = json::value::array();
 
       int idx = 0, out_val_cnt = 0;
@@ -164,7 +149,7 @@ public:
 	std::vector<std::vector<PlaintextT>> make_plaintext_inputs();
 
 	template<typename PlaintextT>
-	std::vector<std::vector<PlaintextT>> make_const_plaintext_inputs();
+	std::vector<PlaintextT> make_const_plaintext_inputs();
 
 	template <typename PlaintextT>
 	void configure_and_run(http_request message);

--- a/pysheep/benchmark_inputs/low_level/circuits/circuit-ADDCONSTANT-1.sheep
+++ b/pysheep/benchmark_inputs/low_level/circuits/circuit-ADDCONSTANT-1.sheep
@@ -1,0 +1,4 @@
+INPUTS input_0
+CONST_INPUTS c_input_0
+OUTPUTS output_0
+ input_0 c_input_0 ADDCONST output_0

--- a/pysheep/benchmark_inputs/low_level/circuits/circuit-MULTBYCONSTANT-1.sheep
+++ b/pysheep/benchmark_inputs/low_level/circuits/circuit-MULTBYCONSTANT-1.sheep
@@ -1,0 +1,4 @@
+INPUTS input_0
+CONST_INPUTS c_input_0
+OUTPUTS output_0
+ input_0 c_input_0 MULTBYCONST output_0

--- a/src/sheep-server.cpp
+++ b/src/sheep-server.cpp
@@ -41,7 +41,7 @@ SheepServer::SheepServer(utility::string_t url) : m_listener(url)
 	//// what contexts are supported?
 	m_available_contexts.push_back("Clear");
 #ifdef HAVE_HElib
-	// m_available_contexts.push_back("HElib_F2");
+	m_available_contexts.push_back("HElib_F2");
 	m_available_contexts.push_back("HElib_Fp");
 #endif
 #ifdef HAVE_TFHE

--- a/src/sheep-server.cpp
+++ b/src/sheep-server.cpp
@@ -106,7 +106,7 @@ template<typename PlaintextT>
 std::vector<std::vector<PlaintextT>>
 SheepServer::make_plaintext_inputs() {
 	std::vector<std::vector<PlaintextT>> inputs;
-	
+
   // TODO: input from json
 
   for (auto input : m_job_config.input_vals) {
@@ -121,13 +121,12 @@ SheepServer::make_plaintext_inputs() {
 
 
 template<typename PlaintextT>
-std::vector<std::vector<PlaintextT>>
+std::vector<PlaintextT>
 SheepServer::make_const_plaintext_inputs() {
-	std::vector<std::vector<PlaintextT>> const_inputs;
-  
+	std::vector<PlaintextT> const_inputs;
+
 	for (auto input : m_job_config.const_input_vals) {
-    std::vector<PlaintextT> input_vector(begin(input), end(input));
-		const_inputs.push_back(input_vector);
+		const_inputs.push_back(input);
 	}
 
 	return const_inputs;
@@ -206,7 +205,7 @@ SheepServer::update_parameters(std::string context_type,
 template <typename PlaintextT>
 bool SheepServer::check_job_outputs(std::vector<std::vector<PlaintextT>> test_outputs,
                                std::vector<std::vector<PlaintextT>> clear_outputs) {
-	
+
   if (test_outputs.size() != clear_outputs.size()) return false;
 
 	for (int i = 0; i < test_outputs.size(); i++) {
@@ -220,7 +219,7 @@ bool SheepServer::check_job_outputs(std::vector<std::vector<PlaintextT>> test_ou
 template <typename PlaintextT>
 void
 SheepServer::configure_and_run(http_request message) {
-  
+
 	if (! m_job_config.isConfigured()) throw std::runtime_error("Job incompletely configured");
 	/// we can now assume we have values for context, inputs, circuit, etc
 	auto context = make_context<PlaintextT>(m_job_config.context);
@@ -230,7 +229,7 @@ SheepServer::configure_and_run(http_request message) {
 	}
 
 	std::vector<std::vector<PlaintextT>> plaintext_inputs = make_plaintext_inputs<PlaintextT>();
-	std::vector<std::vector<PlaintextT>> const_plaintext_inputs = make_const_plaintext_inputs<PlaintextT>();
+	std::vector<PlaintextT> const_plaintext_inputs = make_const_plaintext_inputs<PlaintextT>();
 
 	// shared memory region for returning the results
 	size_t n_outputs = m_job_config.circuit.get_outputs().size();
@@ -274,7 +273,7 @@ SheepServer::configure_and_run(http_request message) {
 		                                      const_plaintext_inputs,
 		                                      timings,
 		                                      m_job_config.eval_strategy);
-		
+
 		if (timings.size() != 3) {
 			// signal an error to the server
 			std::cerr << "Child exiting: more than three timings reported!\n";
@@ -310,7 +309,7 @@ SheepServer::configure_and_run(http_request message) {
 		req.tv_nsec = (timeout_us % 1000000) * 1000;
 		// allow one second grace (since the timeout above refers to the evaluation only
 		req.tv_sec = (timeout_us / 1000000) + 1;
-		
+
     nanosleep(&req, &rem);
 
 		// on waking up, is the child still alive?
@@ -320,7 +319,7 @@ SheepServer::configure_and_run(http_request message) {
 			kill(child_pid, SIGKILL);
 			message.reply(status_codes::InternalError, ("Evaluation timed out"));
 			m_job_finished = false;
-		
+
     } else if (status) {
 			// other abnormal termination (nonzero return or killed by signal)
 			message.reply(status_codes::InternalError, ("Evaluation terminated abnormally"));
@@ -352,13 +351,13 @@ SheepServer::configure_and_run(http_request message) {
 
 				m_job_result.outputs.insert(output);
       }
-      
+
 			auto encryption = std::make_pair<std::string, std::string>("encryption", std::to_string(timings_shared[0].count()));
 			m_job_result.timings.insert(encryption);
-			
+
       auto evaluation = std::make_pair<std::string, std::string>("evaluation", std::to_string(timings_shared[1].count()));
 			m_job_result.timings.insert(evaluation);
-			
+
       auto decryption = std::make_pair<std::string, std::string>("decryption", std::to_string(timings_shared[2].count()));
 			m_job_result.timings.insert(decryption);
 
@@ -520,7 +519,7 @@ void SheepServer::handle_post_inputs(http_request message) {
 			json::value input_dict = jvalue.get();
 			//	auto input_dict = val["input_dict"].as_object();
 			for (auto input_name : m_job_config.input_names) {
-        
+
         std::vector<int> input_vals;
 
         for (auto input : input_dict[input_name].as_array()) {
@@ -541,23 +540,18 @@ void SheepServer::handle_post_inputs(http_request message) {
 
 void SheepServer::handle_post_const_inputs(http_request message) {
 	message.extract_json().then([ = ](pplx::task<json::value> jvalue) {
-		try {
-			json::value input_dict = jvalue.get();
-			//	auto input_dict = val["input_dict"].as_object();
-			for (auto input_name : m_job_config.const_input_names) {
-        
-        std::vector<int> const_input_vals;
-        for (auto input : input_dict[input_name].as_array()) {
-          int input_val = input.as_integer();
-          const_input_vals.push_back(input_val);
-        }
+	    try {
+	      json::value input_dict = jvalue.get();
 
-				m_job_config.const_input_vals.push_back(const_input_vals);
-			}
-		} catch (json::json_exception) {
-			message.reply(status_codes::InternalError, ("Unrecognized inputs"));
-		}
-	});
+	      for (auto input_name : m_job_config.const_input_names) {
+
+		int input_val = input_dict[input_name].as_integer();
+		m_job_config.const_input_vals.push_back(input_val);
+	      }
+	    } catch (json::json_exception) {
+	      message.reply(status_codes::InternalError, ("Unrecognized inputs"));
+	    }
+	  });
 
 	message.reply(status_codes::OK);
 }
@@ -736,6 +730,6 @@ void SheepServer::handle_put_parameters(http_request message) {
 void SheepServer::handle_get_results(http_request message) {
 
 	json::value result = m_job_result.as_json();
-  
+
 	message.reply(status_codes::OK, result);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,7 +43,7 @@ configure_file(undef-output.sheep undef-output.sheep)
 ##################################################################################################
 
  foreach(type IN ITEMS bool int8_t uint8_t)
-     foreach(op IN ITEMS add compare multiply select subtract)
+     foreach(op IN ITEMS add compare multiply select subtract addConst)
          add_executable(test-clear-${type}-${op}
              test-clear-${type}-${op}.cpp
              ${CMAKE_SOURCE_DIR}/src/circuit.cpp

--- a/tests/test-clear-bool-addConst.cpp
+++ b/tests/test-clear-bool-addConst.cpp
@@ -1,6 +1,6 @@
 #include <memory>
 #include <cassert>
-#include "context-helib.hpp"
+#include "context-clear.hpp"
 
 #include "circuit-repo.hpp"
 
@@ -23,7 +23,7 @@ int main(void) {
   std::vector<DurationT> durations;
 
   // The type of the wires in circ are unsigned 8-bit numbers
-  ContextHElib_Fp<bool> ctx;
+  ContextClear<bool> ctx;
 
   // inputs is vector of vectors
   std::vector<std::vector<bool>> inputs = {{1, 0}};

--- a/tests/test-clear-int8_t-addConst.cpp
+++ b/tests/test-clear-int8_t-addConst.cpp
@@ -1,6 +1,6 @@
 #include <memory>
 #include <cassert>
-#include "context-helib.hpp"
+#include "context-clear.hpp"
 
 #include "circuit-repo.hpp"
 
@@ -22,16 +22,16 @@ int main(void) {
   std::cout << C;
   std::vector<DurationT> durations;
 
-  // The type of the wires in circ are unsigned 8-bit numbers
-  ContextHElib_Fp<bool> ctx;
+  // The type of the wires in circ are signed 8-bit numbers
+  ContextClear<int8_t> ctx;
 
   // inputs is vector of vectors
-  std::vector<std::vector<bool>> inputs = {{1, 0}};
+  std::vector<std::vector<int8_t>> inputs = {{-9,2,3,4}};
   // const_inputs is vector (same across slots)
-  std::vector<bool> const_inputs = {1};
-  std::vector<bool> exp_values = {0, 1};
+  std::vector<int8_t> const_inputs = {6};
+  std::vector<int8_t> exp_values = {-3, 8, 9, 10};
 
-  std::vector<std::vector<bool>> result = ctx.eval_with_plaintexts(C, inputs, const_inputs, durations);
+  std::vector<std::vector<int8_t>> result = ctx.eval_with_plaintexts(C, inputs, const_inputs, durations);
 
   for (int i = 0; i < exp_values.size(); i++) {
     std::cout << std::to_string(inputs[0][i]) << " + " <<  std::to_string(const_inputs[0]) << " = " << std::to_string(result[0][i]) << std::endl;

--- a/tests/test-clear-uint8_t-addConst.cpp
+++ b/tests/test-clear-uint8_t-addConst.cpp
@@ -1,6 +1,6 @@
 #include <memory>
 #include <cassert>
-#include "context-helib.hpp"
+#include "context-clear.hpp"
 
 #include "circuit-repo.hpp"
 
@@ -23,15 +23,15 @@ int main(void) {
   std::vector<DurationT> durations;
 
   // The type of the wires in circ are unsigned 8-bit numbers
-  ContextHElib_Fp<bool> ctx;
+  ContextClear<uint8_t> ctx;
 
   // inputs is vector of vectors
-  std::vector<std::vector<bool>> inputs = {{1, 0}};
+  std::vector<std::vector<uint8_t>> inputs = {{117, 2, 3, 4}};
   // const_inputs is vector (same across slots)
-  std::vector<bool> const_inputs = {1};
-  std::vector<bool> exp_values = {0, 1};
+  std::vector<uint8_t> const_inputs = {6};
+  std::vector<uint8_t> exp_values = {123, 8, 9, 10};
 
-  std::vector<std::vector<bool>> result = ctx.eval_with_plaintexts(C, inputs, const_inputs, durations);
+  std::vector<std::vector<uint8_t>> result = ctx.eval_with_plaintexts(C, inputs, const_inputs, durations);
 
   for (int i = 0; i < exp_values.size(); i++) {
     std::cout << std::to_string(inputs[0][i]) << " + " <<  std::to_string(const_inputs[0]) << " = " << std::to_string(result[0][i]) << std::endl;

--- a/tests/test-helib-fp-int8_t-addConst.cpp
+++ b/tests/test-helib-fp-int8_t-addConst.cpp
@@ -1,31 +1,40 @@
 #include <memory>
-
-#include <cstdint>
 #include <cassert>
-#include <algorithm>
 #include "context-helib.hpp"
-#include "circuit-repo.hpp"
-#include "circuit-test-util.hpp"
 
+#include "circuit-repo.hpp"
+
+using namespace SHEEP;
+
+typedef std::chrono::duration<double, std::micro> DurationT;
 
 int main(void) {
-
   using namespace SHEEP;
-  
-	ContextHElib_Fp<int8_t> ctx;
 
-	std::vector<ContextHElib_Fp<int8_t>::Plaintext> pt_input = {15, -42, 120};
-	ContextHElib_Fp<int8_t>::Ciphertext ct = ctx.encrypt(pt_input);
 
-	long const_val = 22;
-	
-	// Perform operation
-	ContextHElib_Fp<int8_t>::Ciphertext ct_out = ctx.AddConstant(ct, const_val);
-	
-	// Decrypt
-	std::vector<ContextHElib_Fp<int8_t>::Plaintext> pt_out = ctx.decrypt(ct_out);
-	
-	assert(pt_out[0] == 37);
-	assert(pt_out[1] == -20);
-	assert(pt_out[2] == -114);
+  Circuit C;
+  Wire in0 = C.add_input("in0");
+  Wire cin0 = C.add_const_input("cin0");
+  Wire out0 = C.add_assignment("out0", Gate::AddConstant, in0, cin0);
+
+  C.set_output(out0);
+
+  std::cout << C;
+  std::vector<DurationT> durations;
+
+  // The type of the wires in circ are unsigned 8-bit numbers
+  ContextHElib_Fp<int8_t> ctx;
+
+  // inputs is vector of vectors
+  std::vector<std::vector<int8_t>> inputs = {{-117, 2, -3, 4}};
+  // const_inputs is vector (same across slots)
+  std::vector<int8_t> const_inputs = {6};
+  std::vector<int8_t> exp_values = {-111, 8, 3, 10};
+
+  std::vector<std::vector<int8_t>> result = ctx.eval_with_plaintexts(C, inputs, const_inputs, durations);
+
+  for (int i = 0; i < exp_values.size(); i++) {
+    std::cout << std::to_string(inputs[0][i]) << " + " <<  std::to_string(const_inputs[0]) << " = " << std::to_string(result[0][i]) << std::endl;
+    assert(result.front()[i] == exp_values[i]);
+  }
 }

--- a/tests/test-helib-fp-uint8_t-addConst.cpp
+++ b/tests/test-helib-fp-uint8_t-addConst.cpp
@@ -1,31 +1,40 @@
 #include <memory>
-
-#include <cstdint>
 #include <cassert>
-#include <algorithm>
 #include "context-helib.hpp"
-#include "circuit-repo.hpp"
-#include "circuit-test-util.hpp"
 
+#include "circuit-repo.hpp"
+
+using namespace SHEEP;
+
+typedef std::chrono::duration<double, std::micro> DurationT;
 
 int main(void) {
-
   using namespace SHEEP;
-  
-	ContextHElib_Fp<uint8_t> ctx;
 
-	std::vector<ContextHElib_Fp<uint8_t>::Plaintext> pt_input = {15, 42, 240};
-	ContextHElib_Fp<uint8_t>::Ciphertext ct = ctx.encrypt(pt_input);
 
-	long const_val = 22;
-	
-	// Perform operation
-	ContextHElib_Fp<uint8_t>::Ciphertext ct_out = ctx.AddConstant(ct, const_val);
-	
-	// Decrypt
-	std::vector<ContextHElib_Fp<uint8_t>::Plaintext> pt_out = ctx.decrypt(ct_out);
-	
-	assert(pt_out[0] == 37);
-	assert(pt_out[1] == 64);
-	assert(pt_out[2] == 6);
+  Circuit C;
+  Wire in0 = C.add_input("in0");
+  Wire cin0 = C.add_const_input("cin0");
+  Wire out0 = C.add_assignment("out0", Gate::AddConstant, in0, cin0);
+
+  C.set_output(out0);
+
+  std::cout << C;
+  std::vector<DurationT> durations;
+
+  // The type of the wires in circ are unsigned 8-bit numbers
+  ContextHElib_Fp<uint8_t> ctx;
+
+  // inputs is vector of vectors
+  std::vector<std::vector<uint8_t>> inputs = {{117, 2, 3, 4}};
+  // const_inputs is vector (same across slots)
+  std::vector<uint8_t> const_inputs = {6};
+  std::vector<uint8_t> exp_values = {123, 8, 9, 10};
+
+  std::vector<std::vector<uint8_t>> result = ctx.eval_with_plaintexts(C, inputs, const_inputs, durations);
+
+  for (int i = 0; i < exp_values.size(); i++) {
+    std::cout << std::to_string(inputs[0][i]) << " + " <<  std::to_string(const_inputs[0]) << " = " << std::to_string(result[0][i]) << std::endl;
+    assert(result.front()[i] == exp_values[i]);
+  }
 }


### PR DESCRIPTION
* adding or multiplying by a constant, we only need one constant val, even if we have slots (following implementation in HElib and SEAL..    Therefore we can turn vector<vector<Plaintext> > back into vector<Plaintext>  for const_inputs. 
* Also fix arguments for multByConst and addConst gates in context.hpp - only take a single ciphertext rather than a vector.
* Add tests for clear-context addConst and multByConst, and update the helib ones to use evalWithPlaintexts.