### PR TITLE
Change notebooks SEAL to SEAL_BFV

### DIFF
--- a/frontend/notebooks/Low-level-benchmarks.ipynb
+++ b/frontend/notebooks/Low-level-benchmarks.ipynb
@@ -50,7 +50,7 @@
    "source": [
     "## Scan 1 \n",
     "Look at the \"levelled\" HE libraries (HElib_Fp, SEAL_BFV, and PALISADE), where we can set parameters that should guarantee correct results on a certain \"depth\" (i.e. number of MULTIPLY operations) without the need for bootstrapping.  \n",
-    "We will try two depth settings - 1 and 10 (note that the parameter choices for SEAL are not very granular).  For each depth setting, we loop over all gates and all input types, and measure the execution time."
+    "We will try two depth settings - 1 and 10 (note that the parameter choices for SEAL_BFV are not very granular).  For each depth setting, we loop over all gates and all input types, and measure the execution time."
    ]
   },
   {
@@ -1246,7 +1246,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "HElib_F2 and TFHE both deal with binary arrays, and by default bootstrap for every operation, while we expect HElib_Fp and SEAL to have execution time independent of bitwidth:"
+    "HElib_F2 and TFHE both deal with binary arrays, and by default bootstrap for every operation, while we expect HElib_Fp and SEAL_BFV to have execution time independent of bitwidth:"
    ]
   },
   {

--- a/frontend/notebooks/Mid-level-benchmarks.ipynb
+++ b/frontend/notebooks/Mid-level-benchmarks.ipynb
@@ -500,7 +500,7 @@
    "source": [
     "So we can see that we correctly selected the value '31'.\n",
     "\n",
-    "Now lets upload this result to the database, and repeat using SEAL.\n"
+    "Now lets upload this result to the database, and repeat using SEAL_BFV.\n"
    ]
   },
   {
@@ -541,7 +541,7 @@
    ],
    "source": [
     "sheep_client.new_job()\n",
-    "sheep_client.set_context(\"SEAL\")\n",
+    "sheep_client.set_context(\"SEAL_BFV\")\n",
     "sheep_client.set_input_type(\"int16_t\")\n",
     "sheep_client.set_circuit(circuit_file)\n",
     "sheep_client.set_inputs(data)\n",
@@ -575,7 +575,7 @@
    "source": [
     "### Plotting the results\n",
     "\n",
-    "We now have the benchmark results in the \"benchmarks\" table of the SQLite database.  We can query this, and see how long HElib and SEAL spent on each operation while processing this circuit."
+    "We now have the benchmark results in the \"benchmarks\" table of the SQLite database.  We can query this, and see how long HElib and SEAL_BFV spent on each operation while processing this circuit."
    ]
   },
   {
@@ -630,19 +630,19 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>SEAL</td>\n",
+       "      <td>SEAL_BFV</td>\n",
        "      <td>MULTIPLY</td>\n",
        "      <td>331335.4</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>SEAL</td>\n",
+       "      <td>SEAL_BFV</td>\n",
        "      <td>ALIAS</td>\n",
        "      <td>1032.5</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
-       "      <td>SEAL</td>\n",
+       "      <td>SEAL_BFV</td>\n",
        "      <td>ADD</td>\n",
        "      <td>2978.1</td>\n",
        "    </tr>\n",
@@ -655,9 +655,9 @@
        "0  HElib_Fp  MULTIPLY  246666.0\n",
        "1  HElib_Fp     ALIAS    3043.2\n",
        "2  HElib_Fp       ADD    6248.5\n",
-       "3      SEAL  MULTIPLY  331335.4\n",
-       "4      SEAL     ALIAS    1032.5\n",
-       "5      SEAL       ADD    2978.1"
+       "3      SEAL_BFV  MULTIPLY  331335.4\n",
+       "4      SEAL_BFV     ALIAS    1032.5\n",
+       "5      SEAL_BFV       ADD    2978.1"
       ]
      },
      "execution_count": 18,
@@ -714,7 +714,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can see that \"MULTIPLY\" is the most time-consuming operation, and SEAL is slightly slower than HElib."
+    "We can see that \"MULTIPLY\" is the most time-consuming operation, and SEAL_BFV is slightly slower than HElib."
    ]
   },
   {
@@ -749,10 +749,10 @@
     }
    ],
    "source": [
-    "# reset the sheep server settings, - this time we'll use uint32_t and SEAL\n",
+    "# reset the sheep server settings, - this time we'll use uint32_t and SEAL_BFV\n",
     "sheep_client.new_job()\n",
     "sheep_client.set_input_type(\"uint32_t\")\n",
-    "sheep_client.set_context(\"SEAL\")"
+    "sheep_client.set_context(\"SEAL_BFV\")"
    ]
   },
   {

--- a/frontend/notebooks/Using_SHEEP_with_slots.ipynb
+++ b/frontend/notebooks/Using_SHEEP_with_slots.ipynb
@@ -163,7 +163,7 @@
    "source": [
     "Note that for these libraries, the computation time will scale with nslots - it is not truly SIMD.\n",
     "\n",
-    "SEAL does support SIMD, and has a large number of slots:"
+    "SEAL_BFV does support SIMD, and has a large number of slots:"
    ]
   },
   {
@@ -184,7 +184,7 @@
    ],
    "source": [
     "sheep_client.new_job()\n",
-    "sheep_client.set_context(\"SEAL\")\n",
+    "sheep_client.set_context(\"SEAL_BFV\")\n",
     "sheep_client.set_input_type(\"int8_t\")\n",
     "sheep_client.get_nslots()"
    ]

--- a/frontend/notebooks/WAHC_demo.ipynb
+++ b/frontend/notebooks/WAHC_demo.ipynb
@@ -667,7 +667,7 @@
     }
    },
    "source": [
-    "SEAL does support SIMD, and the default parameters give us a large number of slots:"
+    "SEAL_BFV does support SIMD, and the default parameters give us a large number of slots:"
    ]
   },
   {
@@ -1284,7 +1284,7 @@
     }
    },
    "source": [
-    "Now lets do the same test with SEAL:"
+    "Now lets do the same test with SEAL_BFV:"
    ]
   },
   {

--- a/frontend/notebooks/matrix_vector_multiplication.ipynb
+++ b/frontend/notebooks/matrix_vector_multiplication.ipynb
@@ -361,7 +361,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Lets upload this to the database, then compare the timings between SEAL and HElib."
+    "Lets upload this to the database, then compare the timings between SEAL_BFV and HElib."
    ]
   },
   {
@@ -799,7 +799,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "So we can see that although SEAL and HElib take very similar time overall to process this circuit, the time is spent in different operations.  \n",
+    "So we can see that although SEAL_BFV and HElib take very similar time overall to process this circuit, the time is spent in different operations.  \n",
     "We can also see that both are a factor >10 faster than doing the computation the naive way."
    ]
   },

--- a/frontend/notebooks/real_and_complex_numbers_SEAL_CKKS.ipynb
+++ b/frontend/notebooks/real_and_complex_numbers_SEAL_CKKS.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Computation with real and complex numbers using the SEAL CKKS context"
+    "## Computation with real and complex numbers using the SEAL_BFV CKKS context"
    ]
   },
   {

--- a/frontend/notebooks/vector_dot_product.ipynb
+++ b/frontend/notebooks/vector_dot_product.ipynb
@@ -63,7 +63,7 @@
     }
    ],
    "source": [
-    "sheep_client.set_context(\"SEAL\")\n",
+    "sheep_client.set_context(\"SEAL_BFV\")\n",
     "sheep_client.set_input_type(\"int8_t\")\n",
     "sheep_client.get_nslots()"
    ]
@@ -256,7 +256,7 @@
    "source": [
     "## Generalizing, and generating circuits\n",
     "\n",
-    "We probably don't want to write circuits by hand, particularly if we are dealing with long vectors (HElib and SEAL can, depending on parameter choices, offer thousands of slots).   We can write a simple python function to generate circuits for arbitrary length vectors:"
+    "We probably don't want to write circuits by hand, particularly if we are dealing with long vectors (HElib and SEAL_BFV can, depending on parameter choices, offer thousands of slots).   We can write a simple python function to generate circuits for arbitrary length vectors:"
    ]
   },
   {
@@ -293,7 +293,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "So, let's do a longer calculation in SEAL - multiply 2 vectors with 100 elements each, where each element is a random number between -10 and 10"
+    "So, let's do a longer calculation in SEAL_BFV - multiply 2 vectors with 100 elements each, where each element is a random number between -10 and 10"
    ]
   },
   {
@@ -377,7 +377,7 @@
     }
    ],
    "source": [
-    "sheep_client.set_context(\"SEAL\")"
+    "sheep_client.set_context(\"SEAL_BFV\")"
    ]
   },
   {


### PR DESCRIPTION
I have tried to run different jupyter notebooks and found that sheep_client.set_context("SEAL") throws an error because SEAL is not in the available context types. 
The fix changes sheep_client.set_context("SEAL") to sheep_client.set_context("SEAL_BFV")

![image](https://user-images.githubusercontent.com/46598884/230130230-741d2042-030e-41bf-889f-21a9b518072d.png)
![image](https://user-images.githubusercontent.com/46598884/230130614-1e85de59-a32e-49e2-9924-b518ecac147a.png)

